### PR TITLE
Investigate "snippet not found" — Scastie wiped anonymous snippets in Nov 2025

### DIFF
--- a/scastie-audit.md
+++ b/scastie-audit.md
@@ -1,0 +1,151 @@
+# Scastie ID audit
+
+Run: 2026-05-11T21:46:31.443Z
+
+## Scastie embed library (`/embedded.js`)
+
+- HTTP status: 200
+- Last-Modified: Tue, 05 May 2026 14:20:56 GMT
+- ETag: "1535f9df8836d40"
+- Content-Length: null
+
+## Summary
+
+- Lessons: 82
+- Unique IDs probed: 164
+- Current IDs: 82 not_found
+- Previous IDs (from 408ae4d~1): 82 not_found
+
+Status legend:
+- `ok` — POST /api/download/<id> returned 200 AND GET /api/snippets/<id> returned a non-empty body. Snippet exists on Scastie.
+- `not_found` — POST /api/download/<id> returned 404. Snippet is gone (or never existed).
+- `empty` — POST returned 200 but GET returned an empty body. Ambiguous; treat as broken.
+- `error_<n>` — unexpected HTTP/fetch error.
+
+## Findings
+
+**The break is server-side, not in this repo.** No code here has changed
+since 2025-05-26 (commit `408ae4d`), and that PR was confirmed working in
+production for ~12 months. Scastie's `/embedded.js` was last-modified on
+**Tue, 2026-05-05 14:20:56 GMT** — about a week before users started
+reporting the issue. That deploy is the most likely trigger.
+
+**Two hypotheses for the actual cause, both consistent with the data:**
+
+1. **Snippets are truly lost.** All 82 current IDs *and* all 82 pre-PR-#31
+   IDs (created years earlier, in distinct batches) return the same
+   `POST /api/download/<id> → 404`. If only one generation were affected
+   we could blame retention/expiration, but both generations failing
+   identically points to a data-side event (purge, migration, or storage
+   reset) coinciding with the 2026-05-05 deploy.
+
+2. **The API shape changed.** `embedded.js` was rebuilt 6 days ago. It
+   could be that the new build sends requests in a form the old recorded
+   IDs no longer match (different namespace, different host, additional
+   required parameter). Our raw probes from this script don't replicate
+   exactly what the embed runtime does, so we can't fully rule this out.
+
+**Caveat: no positive control.** We did not test any known-working
+Scastie snippet. Every ID we probed (164 unique values across both
+generations) returned the same response, so we know "this set of IDs is
+inaccessible", but we cannot independently prove that *any* anonymous
+snippet ID is currently retrievable via the live API. A positive control
+would settle hypothesis 1 vs 2.
+
+**Suggested next probe:** render `https://scastie.scala-lang.org/` (or any
+freshly-created snippet) in a headless browser, capture the network call
+the embed makes to fetch its snippet, and replay that exact call against
+one of our 82 IDs. If the replay succeeds for a fresh snippet but 404s
+for ours → hypothesis 1 (lost data). If even the fresh snippet 404s
+through our replay → hypothesis 2 (we're calling it wrong).
+
+**Reproducing the screenshot.** The "Scala Method with Arguments" lesson
+references `ZDXmAr6wQ4OTcBSHfJCFmw`; that ID returns 404 via the audit,
+which matches the user-visible `//snippet not found` in the editor.
+
+## Per-lesson results
+
+| Lesson | Current ID | Current status | Previous ID | Previous status |
+| --- | --- | --- | --- | --- |
+| _-placeholder | mjfnEbLASjmuk0fZEiBYiQ | not_found (POST 404/42b, GET 200/0b) | y3LB3ugXQKOR4VhY3aaotA | not_found (POST 404/42b, GET 200/0b) |
+| _-wildcard | 0P1RceC9SdOe1Pm3Z8c0lA | not_found (POST 404/42b, GET 200/0b) | VJneetExT8uloX6bomOZ7g | not_found (POST 404/42b, GET 200/0b) |
+| abstract-class | 9JlGE3QOT6StJzBcc6LlZw | not_found (POST 404/42b, GET 200/0b) | fwuSQ1sSRhC5rURpo5vdvw | not_found (POST 404/42b, GET 200/0b) |
+| applicative | OKYzh4QwQFuwLGaNxICYZw | not_found (POST 404/42b, GET 200/0b) | Jmp5pWRLQxeXZwTWT7PpRw | not_found (POST 404/42b, GET 200/0b) |
+| apply | 3yTSEMA7SlKhqIoKT261xg | not_found (POST 404/42b, GET 200/0b) | oyx7X5uwQam2xG8ieQt2BQ | not_found (POST 404/42b, GET 200/0b) |
+| call-by-name-parameters | JonOPclARiarms4qOZ1aIA | not_found (POST 404/42b, GET 200/0b) | XkgpvxRaQdSnfdO2yWuSOg | not_found (POST 404/42b, GET 200/0b) |
+| case-class | J9Wl5OKcRb6LISqNXA4hrQ | not_found (POST 404/42b, GET 200/0b) | 2cLIBX4MTeK7xf7fXBPI4A | not_found (POST 404/42b, GET 200/0b) |
+| case-class-copy | vR4QaHcPSjOyqN0lkqJtTA | not_found (POST 404/42b, GET 200/0b) | zJFFFqP7S5Gym4PZzKLVXA | not_found (POST 404/42b, GET 200/0b) |
+| case-class-unapply | vadTervdRJCmLlcOFsDWfQ | not_found (POST 404/42b, GET 200/0b) | pDSJjw7QQpSvUqFxWxQDlQ | not_found (POST 404/42b, GET 200/0b) |
+| case-object | 0nVUJlV7TO6lnXj4AxRlfw | not_found (POST 404/42b, GET 200/0b) | vzjyjr0WSTOskKtlV1EoDQ | not_found (POST 404/42b, GET 200/0b) |
+| challenge-1 | memyuxazQhCBWeMWI5zJHg | not_found (POST 404/42b, GET 200/0b) | xYbhCpOyRGCalWW4CgA6Iw | not_found (POST 404/42b, GET 200/0b) |
+| class-new | orcSDcLjRwCuRuRke8sm5w | not_found (POST 404/42b, GET 200/0b) | Yqd2MrzTTJy5OdhDffdyyA | not_found (POST 404/42b, GET 200/0b) |
+| companion-objects | wtv124yDQ9yDoSdNgGt66Q | not_found (POST 404/42b, GET 200/0b) | cwwIb13GTha0xT9adIjMqw | not_found (POST 404/42b, GET 200/0b) |
+| comparators | iBb50DUtT0WYfzlVbkPomg | not_found (POST 404/42b, GET 200/0b) | 5MhccpxLQiSzOQ8CWjqjwQ | not_found (POST 404/42b, GET 200/0b) |
+| constraint-inheritance | QkoJXe3PTyC0ZyupcT0B4Q | not_found (POST 404/42b, GET 200/0b) | 1rovwDJFTRaHBS7e2c2ofg | not_found (POST 404/42b, GET 200/0b) |
+| contexts | 2YvBpo1XRQevleQmHm6w6g | not_found (POST 404/42b, GET 200/0b) | IpAmRkEzSOGRRDEFuAp5RA | not_found (POST 404/42b, GET 200/0b) |
+| covariance | Xyrln1IZRtyKqCvtBfHVrA | not_found (POST 404/42b, GET 200/0b) | iFi9nYjrT7OfSifQngJZlw | not_found (POST 404/42b, GET 200/0b) |
+| curry | pm2hh2y4Roa4ncyCvW59nQ | not_found (POST 404/42b, GET 200/0b) | yOTTk60dS4W0xRVsPMejbg | not_found (POST 404/42b, GET 200/0b) |
+| defined-type | sSmyzl5aQcW0iGskJxZIpA | not_found (POST 404/42b, GET 200/0b) | MBpSt9KLQECIxOPK8Phaeg | not_found (POST 404/42b, GET 200/0b) |
+| either | caZffM5rS72X8SdfaV23wQ | not_found (POST 404/42b, GET 200/0b) | bzjEzMzhQmSOiJm2bejFkw | not_found (POST 404/42b, GET 200/0b) |
+| enumeration | BELSTmvmTde8KrAaAumQZQ | not_found (POST 404/42b, GET 200/0b) | RpzCdEpvSnKsBpI1TsckHw | not_found (POST 404/42b, GET 200/0b) |
+| extractor-pattern | WuCy5uDvT1WeeWPg8WcUkg | not_found (POST 404/42b, GET 200/0b) | m2wkxempSUqHNni7KEz1Zg | not_found (POST 404/42b, GET 200/0b) |
+| flatmap | LES1ZVP7TSeBoi9KUJCzkA | not_found (POST 404/42b, GET 200/0b) | ldCLOORGSEGwvfDOlUKDWA | not_found (POST 404/42b, GET 200/0b) |
+| foldable | Ug8xSEt7Tlq7AJU0HkhLbg | not_found (POST 404/42b, GET 200/0b) | q7avzZbtSreqhyrrdrp1kA | not_found (POST 404/42b, GET 200/0b) |
+| foldleft | sk3Ag6h2SAS5LOsxJJsFKw | not_found (POST 404/42b, GET 200/0b) | 1YO5x72fSE686gtMiAxKzQ | not_found (POST 404/42b, GET 200/0b) |
+| for-comprehension | FTZpkSrSRAG8WVFHEVCgFw | not_found (POST 404/42b, GET 200/0b) | Ghu5hkwTQsyazXKdcNujTw | not_found (POST 404/42b, GET 200/0b) |
+| functor | SxNIO0zvSsyJPr1rnkJJTw | not_found (POST 404/42b, GET 200/0b) | lPfrjWhhQUew9oxzlD0nSw | not_found (POST 404/42b, GET 200/0b) |
+| future | t1fKsn4lQVWrzpu359J91g | not_found (POST 404/42b, GET 200/0b) | JkqgIleTS6Sb5Ies2jAKvw | not_found (POST 404/42b, GET 200/0b) |
+| generic-trait | U5lfs4yvS82TMygUeHMctg | not_found (POST 404/42b, GET 200/0b) | 1KailbBGTNCH2CDwVFK4fA | not_found (POST 404/42b, GET 200/0b) |
+| higher-kind | h4vMQgWDTReGLgIJODIe5g | not_found (POST 404/42b, GET 200/0b) | fC18HjQmT6Gbh5mTox5zbw | not_found (POST 404/42b, GET 200/0b) |
+| implicit-class | IVecl2SWQrKJ4BB4tz9wGg | not_found (POST 404/42b, GET 200/0b) | pDE2WSbNTtWv2MetlCCumw | not_found (POST 404/42b, GET 200/0b) |
+| implicit-conversion | BCbTdLn4Sl2vSFsNDWn1bg | not_found (POST 404/42b, GET 200/0b) | 2UnR8tnRRky1rrfT1MNDzw | not_found (POST 404/42b, GET 200/0b) |
+| implicit-proof | j5KUq7jdTaujb5a5bJEH0g | not_found (POST 404/42b, GET 200/0b) | rPQxPMehSye8cwfa4VU9zg | not_found (POST 404/42b, GET 200/0b) |
+| implicit-val | IZZ2VGbPRoWuN2aePc8Lmg | not_found (POST 404/42b, GET 200/0b) | 2u0HgFdmQhmH0WP6aM1dNA | not_found (POST 404/42b, GET 200/0b) |
+| infix-notation | i0Ah55lJQMy7XONJ7Kiuqg | not_found (POST 404/42b, GET 200/0b) | 5YZMNrc1R5WjgZlBc772Kw | not_found (POST 404/42b, GET 200/0b) |
+| list-filter-method | TMCEMboDQTK2EWUvaiDd5g | not_found (POST 404/42b, GET 200/0b) | EVfJS5WZRDWtIdzPHXOs6w | not_found (POST 404/42b, GET 200/0b) |
+| list-flatten | S63YwlmXRh6dvaapW7GV2A | not_found (POST 404/42b, GET 200/0b) | fGhtslb9TiiTQ5brcXpgLg | not_found (POST 404/42b, GET 200/0b) |
+| list-of-option-flatten | WxOdhbt5SNaKM5OYilv36Q | not_found (POST 404/42b, GET 200/0b) | WU5TCyfhTLKRPcvMccymZg | not_found (POST 404/42b, GET 200/0b) |
+| list-parallel | MMl4M3LDQZisDo5AVXOwWg | not_found (POST 404/42b, GET 200/0b) | 8kl0ZPy6T2ycipzz5iNkSg | not_found (POST 404/42b, GET 200/0b) |
+| list-pattern-matching | my7ARfxYS02ArwbEa6U9NQ | not_found (POST 404/42b, GET 200/0b) | i7RNOt1qStGNACeNygqEwQ | not_found (POST 404/42b, GET 200/0b) |
+| list-sum-method | Bk9g8XhJSuS5qgXXlsO17A | not_found (POST 404/42b, GET 200/0b) | WkXaFPHSR7q1M4I7xncZFg | not_found (POST 404/42b, GET 200/0b) |
+| list-zip | mKhYciyqS362m6ZXaWJ70Q | not_found (POST 404/42b, GET 200/0b) | lMLBr2JBQZGtHCaAoZnlRg | not_found (POST 404/42b, GET 200/0b) |
+| literal-identifiers | eGqqiIwaRQOV5jHD55nemg | not_found (POST 404/42b, GET 200/0b) | PpMpUMxaSQyPHkYRKmbRIw | not_found (POST 404/42b, GET 200/0b) |
+| main | phsta85kR2alB3IGPoq5eg | not_found (POST 404/42b, GET 200/0b) | Eb9UJewvRlOeORHTpjD5lQ | not_found (POST 404/42b, GET 200/0b) |
+| map-for-list | LxP34WAsQyq5gV62cPatkg | not_found (POST 404/42b, GET 200/0b) | mqPBMWVGR5OIpa1J9etlYw | not_found (POST 404/42b, GET 200/0b) |
+| method-with-arguments | ZDXmAr6wQ4OTcBSHfJCFmw | not_found (POST 404/42b, GET 200/0b) | P7T6QckdSIKzUFdCdawLEg | not_found (POST 404/42b, GET 200/0b) |
+| methods | 4FCkgVNaT7ucVCga5w5qIA | not_found (POST 404/42b, GET 200/0b) | WAa2MFWwQBW2rIPjVNBgEw | not_found (POST 404/42b, GET 200/0b) |
+| monad | SCUWq9JcRpComfewCgTSFA | not_found (POST 404/42b, GET 200/0b) | JB0wl7zzQxiefAf4EwfzBA | not_found (POST 404/42b, GET 200/0b) |
+| multiple-inheritance | iTqY4AsHScucBLyf9l6j2g | not_found (POST 404/42b, GET 200/0b) | QpCO0GjsTrKBo4wGdIpEJA | not_found (POST 404/42b, GET 200/0b) |
+| objects | ZElvNkmkQ02Qr8sY4isiKA | not_found (POST 404/42b, GET 200/0b) | 1b36QjJlRVi02lvrXSLrgw | not_found (POST 404/42b, GET 200/0b) |
+| operators | avof8zq6RUi0cVKCxnKY7Q | not_found (POST 404/42b, GET 200/0b) | i2ZSLmI0R7egM6vkvJqKug | not_found (POST 404/42b, GET 200/0b) |
+| option | fzBPg5UiSwydGL2dSWKx3A | not_found (POST 404/42b, GET 200/0b) | 77OEvedmT6KHssXPBduEIw | not_found (POST 404/42b, GET 200/0b) |
+| option-map | xWLsuNGXQ7uVnaUE35AyAA | not_found (POST 404/42b, GET 200/0b) | Zn7rGMlnSVWfCH3hCnKEhA | not_found (POST 404/42b, GET 200/0b) |
+| option-pattern-matching | NE1Z1gdMQwO5ppOJOICodg | not_found (POST 404/42b, GET 200/0b) | PDLP0wHGQKqN5oS2yt6R4g | not_found (POST 404/42b, GET 200/0b) |
+| pattern-matching | SnFM3f5GRvCzIvqAWco0jg | not_found (POST 404/42b, GET 200/0b) | 5VQri4WFQ6yrPuBJHNIh5A | not_found (POST 404/42b, GET 200/0b) |
+| pattern-matching-at | k1cFwuZdQheviSdQGDDzMw | not_found (POST 404/42b, GET 200/0b) | xsycVjGaSwubwwjAYM688w | not_found (POST 404/42b, GET 200/0b) |
+| pattern-matching-for-case-class | DSKkBRgZT0unMgVeiG76XQ | not_found (POST 404/42b, GET 200/0b) | v70vPtVcTWmJb6NBzSAnDg | not_found (POST 404/42b, GET 200/0b) |
+| pattern-matching-or | WYfULSwhS12quZ5H6BIkBA | not_found (POST 404/42b, GET 200/0b) | L2xDjw3yTfeVu8BvTlvJuw | not_found (POST 404/42b, GET 200/0b) |
+| random | G7e4QwwbQ4WSkcljUzYcwA | not_found (POST 404/42b, GET 200/0b) | jVPerO3XQwWD2dyHZeWgww | not_found (POST 404/42b, GET 200/0b) |
+| range | kTjI5evhSLyRQBtPRckawA | not_found (POST 404/42b, GET 200/0b) | 3mkgQBbsRAKu0Yqo3tzoxA | not_found (POST 404/42b, GET 200/0b) |
+| recursion | rkgxG7yiSxqHjJAhhKRfqg | not_found (POST 404/42b, GET 200/0b) | Cnic9MRTRE2BgIR3NAC5Zg | not_found (POST 404/42b, GET 200/0b) |
+| regex | ofpEC7pYQ6OaAYH4OQfzsQ | not_found (POST 404/42b, GET 200/0b) | I7Vt5quwT2OLFVHbrpyHlw | not_found (POST 404/42b, GET 200/0b) |
+| repeated-parameters | gdXHGu2KRUC3yVkBl2FhiQ | not_found (POST 404/42b, GET 200/0b) | t4txyXUBQ16HDTrla2PhZw | not_found (POST 404/42b, GET 200/0b) |
+| sealed | 8rWrWX9yQym4w1LxJm56lA | not_found (POST 404/42b, GET 200/0b) | FLCt7eVzRmedD4gb40BpVQ | not_found (POST 404/42b, GET 200/0b) |
+| self-referred-type | wKhJFuWwSw2CE38r1JOT1g | not_found (POST 404/42b, GET 200/0b) | 9fDW3IfPTParnRzONDXkkA | not_found (POST 404/42b, GET 200/0b) |
+| set | wVSrVCeWSeytlVjX0YOSIQ | not_found (POST 404/42b, GET 200/0b) | Xnga8KMIQimJPP8BwT5VAQ | not_found (POST 404/42b, GET 200/0b) |
+| star-parameter | atliFs67TKm6z7r8OSifug | not_found (POST 404/42b, GET 200/0b) | uhVWCfgeREWEbRKVUX639w | not_found (POST 404/42b, GET 200/0b) |
+| stream | 5lF704InT2mzBKntjzsU9Q | not_found (POST 404/42b, GET 200/0b) | HXLsbXJQSVSKmS333hXm6w | not_found (POST 404/42b, GET 200/0b) |
+| string-format | tMiJL0glR3exHoEdGFKZBQ | not_found (POST 404/42b, GET 200/0b) | G0GDlJ2GQ2O9w05HPQycGA | not_found (POST 404/42b, GET 200/0b) |
+| string-interpolation | lwH1J4fdSsWs2JC9b5Hykg | not_found (POST 404/42b, GET 200/0b) | YvHTOaC8SFCFpKzQLmd9ag | not_found (POST 404/42b, GET 200/0b) |
+| thread-sleep | BjJXlvkMRtWCqIJ1y1oWrw | not_found (POST 404/42b, GET 200/0b) | W8rybNOdRk29mQwdFVjqNg | not_found (POST 404/42b, GET 200/0b) |
+| trait | wNjtWIW8QXy3E3R5D1tNUA | not_found (POST 404/42b, GET 200/0b) | PcemiDBSR1ejWZaPaVxjqQ | not_found (POST 404/42b, GET 200/0b) |
+| traversable | 3R7qyi15SqGPmU0yqMfvxQ | not_found (POST 404/42b, GET 200/0b) | ntaMRDzYQ3uMMgXbQZcECg | not_found (POST 404/42b, GET 200/0b) |
+| try | SQcoS39XQ3SvkpwJJkCT7w | not_found (POST 404/42b, GET 200/0b) | TgKc6NXwSE2LWikrBm4Qtw | not_found (POST 404/42b, GET 200/0b) |
+| tuple | T2FtLvkXR3O8M6P6LCYurQ | not_found (POST 404/42b, GET 200/0b) | TUuvqIPHTc2A3jHNSYMBBQ | not_found (POST 404/42b, GET 200/0b) |
+| typeclass | gIyJLpp3QBq2Azewca2sMw | not_found (POST 404/42b, GET 200/0b) | UtjWBavyRMWd7mpfLiXlfQ | not_found (POST 404/42b, GET 200/0b) |
+| unapply-magic | IX9WqgZ4SPeTmId5tUX9GQ | not_found (POST 404/42b, GET 200/0b) | 3dUlzSLfRMqUFGOQ1Ms8vA | not_found (POST 404/42b, GET 200/0b) |
+| upper-constraint | pnGE3sx2QF618zNKhKhoLw | not_found (POST 404/42b, GET 200/0b) | wYG9m3B3T1qBOuvy5vLjAQ | not_found (POST 404/42b, GET 200/0b) |
+| val-lazy-def | r2ZO6YV9TsSQWF5resaN1A | not_found (POST 404/42b, GET 200/0b) | fRqDtrL9Q22S2aB2Pue9mg | not_found (POST 404/42b, GET 200/0b) |
+| val-pattern-matching | KpCh2LvkSza9Apd7RaoNEA | not_found (POST 404/42b, GET 200/0b) | aLWSbioJT0ir0qACbt6yCg | not_found (POST 404/42b, GET 200/0b) |
+| values | V5hjMfbkSb28UEedNKP2zw | not_found (POST 404/42b, GET 200/0b) | 6EuSjLIMT7KQhdUiB7Nf8Q | not_found (POST 404/42b, GET 200/0b) |
+| visibility | Dp3Hyvw4Tiagf7AG6nIuvw | not_found (POST 404/42b, GET 200/0b) | 8lBYPLO0RAGZLT1C7idAuw | not_found (POST 404/42b, GET 200/0b) |

--- a/scastie-audit.md
+++ b/scastie-audit.md
@@ -24,44 +24,51 @@ Status legend:
 
 ## Findings
 
-**The break is server-side, not in this repo.** No code here has changed
-since 2025-05-26 (commit `408ae4d`), and that PR was confirmed working in
-production for ~12 months. Scastie's `/embedded.js` was last-modified on
-**Tue, 2026-05-05 14:20:56 GMT** — about a week before users started
-reporting the issue. That deploy is the most likely trigger.
+**Snippets are truly lost. This is not an API shape change.** Scastie's
+maintainer ([@rochala](https://github.com/rochala)) confirmed in
+[scalacenter/scastie#1204](https://github.com/scalacenter/scastie/issues/1204)
+on 2025-11-14:
 
-**Two hypotheses for the actual cause, both consistent with the data:**
+> "we've cleaned the database of anonymous snippets and from now on they
+> will not be stored indefinitely. If someone wants to have persistent
+> snippets they now need to login."
 
-1. **Snippets are truly lost.** All 82 current IDs *and* all 82 pre-PR-#31
-   IDs (created years earlier, in distinct batches) return the same
-   `POST /api/download/<id> → 404`. If only one generation were affected
-   we could blame retention/expiration, but both generations failing
-   identically points to a data-side event (purge, migration, or storage
-   reset) coinciding with the 2026-05-05 deploy.
+And on 2025-11-18:
 
-2. **The API shape changed.** `embedded.js` was rebuilt 6 days ago. It
-   could be that the new build sends requests in a form the old recorded
-   IDs no longer match (different namespace, different host, additional
-   required parameter). Our raw probes from this script don't replicate
-   exactly what the embed runtime does, so we can't fully rule this out.
+> "All non-anonymous snippets of users who did not login for 2.5 years
+> and did not accept new privacy policy were also deleted... I already
+> spent way too long fighting with mongodb before I brought the idea to
+> drop all anonymous snippets"
 
-**Caveat: no positive control.** We did not test any known-working
-Scastie snippet. Every ID we probed (164 unique values across both
-generations) returned the same response, so we know "this set of IDs is
-inaccessible", but we cannot independently prove that *any* anonymous
-snippet ID is currently retrievable via the live API. A positive control
-would settle hypothesis 1 vs 2.
+All of tour-of-scala's snippets were created anonymously (PR #31 in
+May 2025 and earlier), so they were caught by the November 2025 wipe.
+This audit's data is consistent with that statement: both the
+post-PR-#31 IDs (created May 2025) and the pre-PR-#31 IDs (created
+years earlier) return identical 404s. The 2026-05-05 `embedded.js`
+rebuild is unrelated — the data was already gone six months before then.
 
-**Suggested next probe:** render `https://scastie.scala-lang.org/` (or any
-freshly-created snippet) in a headless browser, capture the network call
-the embed makes to fetch its snippet, and replay that exact call against
-one of our 82 IDs. If the replay succeeds for a fresh snippet but 404s
-for ours → hypothesis 1 (lost data). If even the fresh snippet 404s
-through our replay → hypothesis 2 (we're calling it wrong).
+**Reproducing the screenshot.** The "Scala Method with Arguments"
+lesson references `ZDXmAr6wQ4OTcBSHfJCFmw`; that ID returns 404 via the
+audit, which matches the user-visible `//snippet not found` in the
+editor.
 
-**Reproducing the screenshot.** The "Scala Method with Arguments" lesson
-references `ZDXmAr6wQ4OTcBSHfJCFmw`; that ID returns 404 via the audit,
-which matches the user-visible `//snippet not found` in the editor.
+## Implications for tour-of-scala
+
+- The snippets are not coming back. Scastie will not restore them.
+- Re-creating them as anonymous snippets on scastie.scala-lang.org
+  would only buy time — the new policy is "not stored indefinitely",
+  so they would be wiped again.
+- Durable options:
+  1. **Re-create under a Scastie account.** Snippets owned by a
+     logged-in user appear to be retained (with the 2.5-year inactivity
+     caveat). The URL shape changes from `/<base64UUID>` to
+     `/<login>/<base64UUID>/latest`, which `components/scastie.js`
+     would need to support.
+  2. **Stop depending on Scastie.** Embed code locally (a static block
+     for display + optional "Open in Scastie" link). Removes the
+     external dependency entirely.
+  3. **Switch to another playground** (scala-cli web, Scala 3
+     scastie-alternative, etc.).
 
 ## Per-lesson results
 

--- a/scripts/audit-scastie-ids.mjs
+++ b/scripts/audit-scastie-ids.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Audit every lesson's Scastie snippet ID against scastie.scala-lang.org and
+// write a markdown report to scastie-audit.md. Investigation-only: does not
+// modify any lesson page.
+//
+// Usage: node scripts/audit-scastie-ids.mjs
+
+import { execFileSync } from 'node:child_process'
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = resolve(HERE, '..')
+const LESSONS_DIR = resolve(REPO, 'pages/scala')
+const REPORT_PATH = resolve(REPO, 'scastie-audit.md')
+
+// Commit that bulk-replaced every scastieId. 408ae4d~1 is the last revision
+// with the previous (pre-PR-#31) IDs.
+const PREV_REV = '408ae4d~1'
+
+const SCASTIE_HOST = 'https://scastie.scala-lang.org'
+const CONCURRENCY = 5
+
+const ID_RE = /const\s+scastieId\s*=\s*"([^"]+)"/
+
+function extractId(source) {
+  const m = source.match(ID_RE)
+  return m ? m[1] : null
+}
+
+function listLessons() {
+  return readdirSync(LESSONS_DIR)
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => f.replace(/\.js$/, ''))
+    .sort()
+}
+
+function currentId(slug) {
+  return extractId(readFileSync(resolve(LESSONS_DIR, `${slug}.js`), 'utf8'))
+}
+
+function previousId(slug) {
+  try {
+    const out = execFileSync(
+      'git',
+      ['show', `${PREV_REV}:pages/scala/${slug}.js`],
+      { cwd: REPO, stdio: ['ignore', 'pipe', 'ignore'] },
+    ).toString('utf8')
+    return extractId(out)
+  } catch {
+    return null // lesson didn't exist at that revision
+  }
+}
+
+async function probe(id) {
+  // Two complementary probes:
+  //   * POST /api/download/<id> — clean 200 vs 404
+  //   * GET  /api/snippets/<id> — what the embed actually hits;
+  //     content-length distinguishes hit (>0) from miss (=0)
+  const download = await fetch(`${SCASTIE_HOST}/api/download/${id}`, {
+    method: 'POST',
+  })
+  const downloadBody = await download.text()
+
+  const snippet = await fetch(`${SCASTIE_HOST}/api/snippets/${id}`, {
+    headers: { Accept: 'application/json' },
+  })
+  const snippetBody = await snippet.text()
+
+  let status
+  if (download.status === 200 && snippetBody.length > 0) status = 'ok'
+  else if (download.status === 404) status = 'not_found'
+  else if (download.status === 200 && snippetBody.length === 0) status = 'empty'
+  else status = `error_${download.status}`
+
+  return {
+    status,
+    downloadStatus: download.status,
+    downloadBytes: downloadBody.length,
+    snippetStatus: snippet.status,
+    snippetBytes: snippetBody.length,
+  }
+}
+
+async function probeAll(ids) {
+  const cache = new Map()
+  const queue = [...ids]
+  const workers = Array.from({ length: CONCURRENCY }, async () => {
+    while (queue.length) {
+      const id = queue.shift()
+      if (cache.has(id)) continue
+      try {
+        cache.set(id, await probe(id))
+      } catch (e) {
+        cache.set(id, { status: `error_${e.code || 'fetch'}` })
+      }
+    }
+  })
+  await Promise.all(workers)
+  return cache
+}
+
+async function embedMeta() {
+  const res = await fetch(`${SCASTIE_HOST}/embedded.js`, { method: 'HEAD' })
+  return {
+    status: res.status,
+    lastModified: res.headers.get('last-modified'),
+    etag: res.headers.get('etag'),
+    contentLength: res.headers.get('content-length'),
+  }
+}
+
+function summarize(rows, key) {
+  const counts = {}
+  for (const r of rows) {
+    const s = r[key]?.status ?? 'missing_id'
+    counts[s] = (counts[s] ?? 0) + 1
+  }
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `${v} ${k}`)
+    .join(' / ')
+}
+
+function fmtCell(probe) {
+  if (!probe) return '—'
+  return `${probe.status} (POST ${probe.downloadStatus}/${probe.downloadBytes}b, GET ${probe.snippetStatus}/${probe.snippetBytes}b)`
+}
+
+async function main() {
+  const slugs = listLessons()
+  console.log(`Found ${slugs.length} lessons.`)
+
+  const rows = slugs.map((slug) => ({
+    slug,
+    cur: currentId(slug),
+    prev: previousId(slug),
+  }))
+
+  const uniqueIds = new Set()
+  for (const r of rows) {
+    if (r.cur) uniqueIds.add(r.cur)
+    if (r.prev && r.prev !== r.cur) uniqueIds.add(r.prev)
+  }
+  console.log(`Probing ${uniqueIds.size} unique IDs...`)
+
+  const [cache, embed] = await Promise.all([probeAll(uniqueIds), embedMeta()])
+
+  for (const r of rows) {
+    r.curProbe = r.cur ? cache.get(r.cur) : null
+    r.prevProbe = r.prev ? cache.get(r.prev) : null
+  }
+
+  const lines = []
+  lines.push('# Scastie ID audit')
+  lines.push('')
+  lines.push(`Run: ${new Date().toISOString()}`)
+  lines.push('')
+  lines.push('## Scastie embed library (`/embedded.js`)')
+  lines.push('')
+  lines.push(`- HTTP status: ${embed.status}`)
+  lines.push(`- Last-Modified: ${embed.lastModified}`)
+  lines.push(`- ETag: ${embed.etag}`)
+  lines.push(`- Content-Length: ${embed.contentLength}`)
+  lines.push('')
+  lines.push('## Summary')
+  lines.push('')
+  lines.push(`- Lessons: ${rows.length}`)
+  lines.push(`- Unique IDs probed: ${uniqueIds.size}`)
+  lines.push(`- Current IDs: ${summarize(rows, 'curProbe')}`)
+  lines.push(`- Previous IDs (from ${PREV_REV}): ${summarize(rows, 'prevProbe')}`)
+  lines.push('')
+  lines.push('Status legend:')
+  lines.push('- `ok` — POST /api/download/<id> returned 200 AND GET /api/snippets/<id> returned a non-empty body. Snippet exists on Scastie.')
+  lines.push('- `not_found` — POST /api/download/<id> returned 404. Snippet is gone (or never existed).')
+  lines.push('- `empty` — POST returned 200 but GET returned an empty body. Ambiguous; treat as broken.')
+  lines.push('- `error_<n>` — unexpected HTTP/fetch error.')
+  lines.push('')
+  lines.push('## Per-lesson results')
+  lines.push('')
+  lines.push('| Lesson | Current ID | Current status | Previous ID | Previous status |')
+  lines.push('| --- | --- | --- | --- | --- |')
+  for (const r of rows) {
+    lines.push(
+      `| ${r.slug} | ${r.cur ?? '—'} | ${fmtCell(r.curProbe)} | ${r.prev ?? '—'} | ${fmtCell(r.prevProbe)} |`,
+    )
+  }
+  lines.push('')
+
+  writeFileSync(REPORT_PATH, lines.join('\n'))
+  console.log(`Wrote ${REPORT_PATH}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Users reported `//snippet not found` in the Scastie embed on lesson pages. This PR is **investigation only** — no production code is changed.

- `scripts/audit-scastie-ids.mjs` — probes scastie.scala-lang.org for every lesson's current `scastieId` and its pre-PR-#31 `scastieId`, dumps embed-library metadata.
- `scastie-audit.md` — generated report with findings and recommendations.

## Root cause (confirmed)

Scastie's maintainer @rochala deliberately wiped the anonymous snippet database in November 2025 — see [scalacenter/scastie#1204](https://github.com/scalacenter/scastie/issues/1204):

> 2025-11-14: "we've cleaned the database of anonymous snippets and from now on they will not be stored indefinitely. If someone wants to have persistent snippets they now need to login."
>
> 2025-11-18: "All non-anonymous snippets of users who did not login for 2.5 years and did not accept new privacy policy were also deleted... I already spent way too long fighting with mongodb before I brought the idea to drop all anonymous snippets"

All 82 of our lesson snippets were saved anonymously (PR #31 in May 2025 and earlier), so they were caught by the wipe. The audit confirms it: every current ID and every pre-PR-#31 ID returns 404 today.

## Implications

- Snippets are not coming back. Scastie will not restore them.
- Re-creating them anonymously would only repeat the cycle — the new policy is "not stored indefinitely."
- Durable options (detailed in the report):
  1. **Re-create under a Scastie account** — snippets owned by a logged-in user are retained. URL shape becomes `/<login>/<base64UUID>/latest`, which `components/scastie.js` needs to support.
  2. **Drop the Scastie dependency** — host code blocks locally with an optional "Open in Scastie" link.
  3. **Switch playgrounds.**

Awaiting your call on which direction to take before making any code changes.

## Test plan

- [ ] `node scripts/audit-scastie-ids.mjs` runs to completion (Node 18+).
- [ ] `scastie-audit.md` is regenerated; row for `method-with-arguments` shows `not_found`.
- [ ] `git status` shows only the two new files; no `pages/scala/*.js` modified.

https://claude.ai/code/session_01Smva6wsURw8idy3EM4DSkF